### PR TITLE
Remove use strict

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,14 @@
-'use strict';
-
 var format = require('util').format;
 var jsen = require('jsen');
 var _ = require('lodash');
 var jsonSchemaError = require('./libs/json_schema_error');
 
-const DEFINITION_NOT_FOUND = 'Could not find \'%s\'.';
-const LINKS_NOT_FOUND = 'Schema does not contain links array.';
-const SCHEMA_NOT_FOUND = 'Could not find schema for \'%s\' \'%s\'.';
-const INVALID_DATA = 'Invalid data.';
-const MISSING_PROP = 'Must supply \'%s\' prop.';
-const REQUIRED_PROPS = ['url', 'method'];
+var DEFINITION_NOT_FOUND = 'Could not find \'%s\'.';
+var LINKS_NOT_FOUND = 'Schema does not contain links array.';
+var SCHEMA_NOT_FOUND = 'Could not find schema for \'%s\' \'%s\'.';
+var INVALID_DATA = 'Invalid data.';
+var MISSING_PROP = 'Must supply \'%s\' prop.';
+var REQUIRED_PROPS = ['url', 'method'];
 
 exports.definition = definition;
 exports.schema = schema;
@@ -19,13 +17,13 @@ exports.resource = resource;
 
 exports.validate = function(schemata, props, data) {
   return new Promise((resolve, reject) => {
-    let validator, res;
+    var validator, res;
 
     try {
       props = checkProps(props);
       res = resource(props.url);
 
-      let doc = _.compose(
+      var doc = _.compose(
         mandatory(schemata, res),
         schema(props),
         definition(schemata)
@@ -36,10 +34,10 @@ exports.validate = function(schemata, props, data) {
       reject(new jsonSchemaError(e.message));
     }
 
-    let valid = validator(namespaceData(res, data));
+    var valid = validator(namespaceData(res, data));
 
     if (!valid && validator.errors.length) {
-      let props = {fields: validator.errors};
+      var props = {fields: validator.errors};
       return reject(new jsonSchemaError(INVALID_DATA, props));
     }
 
@@ -50,10 +48,10 @@ exports.validate = function(schemata, props, data) {
 function definition(schemata) {
   return (resource) => {
     resource = ['definitions', resource];
-    let found = _.get(schemata, resource);
+    var found = _.get(schemata, resource);
 
     if (!found) {
-      let path = resource.join('.');
+      var path = resource.join('.');
       throw new jsonSchemaError(format(DEFINITION_NOT_FOUND, path));
     } else return found;
   };
@@ -61,16 +59,16 @@ function definition(schemata) {
 
 function schema(props) {
   return (definition) => {
-    let links = _.get(definition, 'links');
+    var links = _.get(definition, 'links');
 
     if (!links) throw new jsonSchemaError(LINKS_NOT_FOUND);
 
     try { props = checkProps(props); } catch(e) { throw e; }
 
-    let schemata = _.chain(links)
+    var schemata = _.chain(links)
       .find((a) => {
-        let method = strCompare(a.method, props.method);
-        let url = strCompare(a.href, props.url);
+        var method = strCompare(a.method, props.method);
+        var url = strCompare(a.href, props.url);
 
         return method && url;
       })
@@ -78,7 +76,7 @@ function schema(props) {
       .value();
 
     if (!schemata) {
-      let msg = format(SCHEMA_NOT_FOUND, props.method, props.url);
+      var msg = format(SCHEMA_NOT_FOUND, props.method, props.url);
       throw new jsonSchemaError(msg);
     }
 
@@ -88,11 +86,11 @@ function schema(props) {
 
 function mandatory(schemata, resource) {
   return (spec) => {
-    let need = _.get(spec, 'required');
+    var need = _.get(spec, 'required');
 
     if (!need) return schemata;
 
-    let clone = _.cloneDeep(schemata);
+    var clone = _.cloneDeep(schemata);
     _.assign(clone.definitions[resource], {required: need});
     return clone;
   };
@@ -107,8 +105,8 @@ function checkProps(props) {
 }
 
 function resource(url) {
-  let del = '/';
-  let str = _.first(url.split(del).filter((part) => part != ''));
+  var del = '/';
+  var str = _.first(url.split(del).filter((part) => part != ''));
   if (isPlural(str)) str = str.slice(0, -1);
   return str;
 }
@@ -126,7 +124,7 @@ function strCompare(s1, s2) {
 }
 
 function namespaceData(resource, data) {
-  let body = {};
+  var body = {};
   body[resource] = data;
   return body;
 }


### PR DESCRIPTION
Removing `use strict` as this is causing conflict when using `const` for projects with ES6 transpilers.

A minor change over here will produce smiles elsewhere.
