### PR TITLE
Update method compare

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ exports.resource = resource;
 exports.decodeMethod = decodeMethod;
 exports.getParam = getParam;
 exports.urlCompare = urlCompare;
+exports.normalizeRef = normalizeRef;
 
 exports.validate = function(schemata, attr, data, opts) {
   return new Promise(function(resolve, reject) {
@@ -149,11 +150,16 @@ function urlCompare(source, target) {
   var decoded = decodeMethod(source);
 
   if (decoded.indexOf(splitter) != -1) {
-    var base = source.split(splitter)[0];
+    decoded = normalizeRef(decoded);
+    var base = decoded.split(splitter)[0];
     var param = getParam(decoded);
     source = base += ':' + param;
   }
 
   var re = pathToRegexp(source);
   return re.test(target);
+}
+
+function normalizeRef(source) {
+  return source.replace(/\{\(/g, '').replace(/\)\}/g, '');
 }

--- a/test/index.js
+++ b/test/index.js
@@ -179,12 +179,25 @@ describe('jsonSchema', function() {
 
   describe('.urlCompare', function() {
     before(function() {
-      this.source = '/users/#/definitions/user/definitions/id';
+      this.source = '/users/{(%23%2Fdefinitions%2Fuser%2Fdefinitions%2Fid)}';
       this.target = '/users/abc123';
     });
 
     it('must return true', function() {
       assert(jsonSchema.urlCompare(this.source, this.target));
+    });
+  });
+
+  describe('.normalizeRef', function() {
+    it('must not remove unintended characters', function() {
+      var source = 'hey{(';
+      assert(jsonSchema.normalizeRef(source).indexOf('hey') != -1);
+    });
+
+    it('must remove characters', function() {
+      var source = 'hey{(there)}you!';
+      assert(jsonSchema.normalizeRef(source).indexOf('{(') < 0);
+      assert(jsonSchema.normalizeRef(source).indexOf(')}') < 0);
     });
   });
 });


### PR DESCRIPTION
Removes remaining `{(` and `)}` characters from `urlCompare` method.
