### PR TITLE
Fix isPlural compatibility with older browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function resource(url) {
 }
 
 function isPlural(str) {
-  return str.endsWith('s');
+  return str.indexOf('s', str.length - 1) !== -1;
 }
 
 function toUpper(str) {


### PR DESCRIPTION
This patch: 

• Makes sure isPlural() works across older browsers. String.endsWith is not supported in older browsers. 
